### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.2.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/actions/parse.yaml
+++ b/actions/parse.yaml
@@ -1,6 +1,6 @@
 ---
 name: parse
-runner_type: run-python
+runner_type: python-script
 description: Parse XML string and return JSON object.
 enabled: true
 entry_point: parse_xml.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - serialization
   - deserialization
   - text processing
-version : 0.1.0
+version : 0.2.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.